### PR TITLE
Use averaging for sex estimation

### DIFF
--- a/biolearn/model.py
+++ b/biolearn/model.py
@@ -239,7 +239,11 @@ model_definitions = {
         "tissue": "Blood",
         "source": "https://bmcgenomics.biomedcentral.com/articles/10.1186/s12864-021-07675-2",
         "output": "Sex",
-        "model": {"type": "SexEstimationModel", "file": "estimateSex.csv"},
+        "model": {
+            "type": "SexEstimationModel",
+            "file": "estimateSex.csv",
+            "default_imputation": "averaging",
+        },
     },
     "LeeRefinedRobust": {
         "year": 2019,


### PR DESCRIPTION
Default imputation takes an extremely long time since the sex estimation model requests every methylation site in 450k. This changes it to use averaging imputation by default which will be much faster. 

Closes https://github.com/bio-learn/biolearn/issues/56