### PR TITLE
Add curated tags to merged library

### DIFF
--- a/scripts/sync_library_entry_to_notion.py
+++ b/scripts/sync_library_entry_to_notion.py
@@ -42,8 +42,9 @@ class SelectProperty(NotionDatabaseProperty):
             type=property["type"],
             select=(
                 SelectPropertyValue(**property["select"])
-                if property["select"]
+                if "select" in property
                 else None
+
             ),
         )
 
@@ -97,7 +98,7 @@ class NumberProperty(NotionDatabaseProperty):
         return NumberProperty(
             id=property["id"],
             type=property["type"],
-            number=int(property["number"]) if property["number"] else None,
+            number=int(property["number"]) if "number" in property else None,
         )
 
 
@@ -321,7 +322,7 @@ def create_notion_page_creation(local_item: SeriesItem) -> dict:
         "rich_text": [{"text": {"content": local_item.title}}]
     }
     platforms = [
-        {"name": platform["name"]} for platform in local_item.platforms
+        {"name": platform["name"]} for platform in (local_item.platforms or [])
     ]
     creation["properties"]["Platform"] = {"multi_select": platforms}
     creation["properties"]["Samples"] = {"number": local_item.samples}
@@ -384,7 +385,7 @@ def create_notion_page_update(
     notion_platforms = [
         select.name for select in remote_item.properties.Platform.multi_select
     ]
-    local_platforms = [platform["name"] for platform in local_item.platforms]
+    local_platforms = [platform["name"] for platform in (local_item.platforms or [])]
     if set(local_platforms) != set(notion_platforms):
         update["Platform"] = {
             "multi_select": [

--- a/scripts/sync_library_entry_to_notion.py
+++ b/scripts/sync_library_entry_to_notion.py
@@ -245,16 +245,8 @@ def read_series_dataset_from_library() -> list[SeriesItem]:
     with open(library, "r") as file:
         library_data = yaml.safe_load(file)
         library_items = [dict_to_dataclass(SeriesItem, item) for item in library_data["items"]]
-
-        # Assume all handed generated ones are curated and loadable
-        default_tags = ["curated", "loadable"]
-        for item in library_items:
-            if item.tags is None:
-                item.tags = default_tags.copy()
-            else:
-                item.tags.extend(default_tags)
         
-        # Assume all manually curated entries have age and sex metadata
+        # Set age and sex presence fields for library items
         for item in library_items:
             item.age_present = True
             item.sex_present = True


### PR DESCRIPTION
This PR combines library data from the `autoscan_library` and `library` data sources and synchronizes the merged result to a Notion page. The merge logic has two key aspects:

- The content of `library.yaml` takes priority in case of conflicts between the data sources.
- The `library.yaml` data is assumed to be 'curated' and 'loadable'.