### PR TITLE
Fix/96 datalinks - feat: support composite‑dataset datalinks (Fixes #96)

### DIFF
--- a/biolearn/data/library.yaml
+++ b/biolearn/data/library.yaml
@@ -889,6 +889,9 @@ items:
   parser:
     type: jen-age-custom
     data-type: rna
+  datalinks:
+    - https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE103232
+    - https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE75337
 - id: BoAChallengeData
   title: 2024 Biomarkers of Aging Challenge Sample Data
   summary: We generated DNA methylation profiles of 500 diverse individuals to enable
@@ -924,6 +927,8 @@ items:
       age:
         row: 45
         parse: numeric
+  datalinks:
+    - https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE246337
 - id: GSE167998
   title: 'FlowSorted.BloodExtended.EPIC: An Enhanced DNA Methylation Library for Deconvoluting
     Peripheral Blood'

--- a/doc/generate.py
+++ b/doc/generate.py
@@ -67,7 +67,7 @@ def generate_data_csv_from_yaml(yaml_file, output_file="generated/data_table.csv
                 geo_link = f"`{item['id']} <{links[0]}>`_"
             else:
                 geo_link = item['id'] + "".join(
-                    f"`({i+1}) <{url}>`_" for i, url in enumerate(links)
+                    f" `({i+1}) <{url}>`_" for i, url in enumerate(links)
                 )
             title = item['title'][:60] + '...' if len(item['title']) > 60 else item['title']
             row = [

--- a/doc/generate.py
+++ b/doc/generate.py
@@ -59,7 +59,16 @@ def generate_data_csv_from_yaml(yaml_file, output_file="generated/data_table.csv
         for item in yaml_data["items"]:
             age_present = "Yes" if "age" in item.get("parser", {}).get("metadata", {}) else "No"
             sex_present = "Yes" if "sex" in item.get("parser", {}).get("metadata", {}) else "No"
-            geo_link = f"`{item['id']} <https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc={item['id']}>`_"
+            # Build hyperlink(s) depending on optional datalinks
+            links = item.get("datalinks", [])
+            if not links:
+                geo_link = f"`{item['id']} <https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc={item['id']}>`_"
+            elif len(links) == 1:
+                geo_link = f"`{item['id']} <{links[0]}>`_"
+            else:
+                geo_link = item['id'] + "".join(
+                    f"`({i+1}) <{url}>`_" for i, url in enumerate(links)
+                )
             title = item['title'][:60] + '...' if len(item['title']) > 60 else item['title']
             row = [
                 geo_link,


### PR DESCRIPTION
### What & Why
* Adds optional `datalinks` list to `biolearn/data/library.yaml` for composite datasets  
  * **BoAChallengeData** → one link (GSE246337)  
  * **JenAge** → two links (GSE103232, GSE75337)
* Extends `doc/generate.py` with three‑branch logic  
  * fallback to GEO pattern when `datalinks` absent  
  * single explicit link  
  * numbered links when >1 URL
* Keeps backward compatibility for every existing dataset.

### Rebase / Tests
* Rebased onto latest `master` after recent merges.  
* **pytest**: 114 passed, 1 skipped.  
* Docs build (`make docs`) renders without warnings.

### Visual proof
<!-- Replace the placeholder with an actual screenshot or remove this section -->
![data-table](<attach_screenshot_here>)

### Checklist
- [x] code formatted (`pre-commit run --all-files`)
- [x] tests green
- [x] docs build clean
- [x] backward compatible

Fixes #96