### PR TITLE
Add cache invalidation

### DIFF
--- a/biolearn/cache.py
+++ b/biolearn/cache.py
@@ -1,140 +1,195 @@
+"""
+Category- and version-aware cache utilities for Biolearn.
+"""
+from __future__ import annotations
+
 import os
-import shutil
 import pickle
+import shutil
+from typing import Any
+
+__all__ = ["NoCache", "LocalFolderCache"]
+
+
+def _compose_filename(key: str, category: str, version: str) -> str:
+    """
+    Construct the filename for a cache entry.
+
+    Args:
+        key: Unique key identifying the cache entry.
+        category: Cache category name.
+        version: Version string for invalidation.
+
+    Returns:
+        Filename string including key, category, and version.
+    """
+    return f"{key}__{category}__{version}.pkl"
 
 
 class NoCache:
-    """
-    A cache implementation that does nothing.
-    """
+    """A no-op cache implementation (always misses)."""
 
-    def get(self, key):
+    def get(self, key: str, category: str, version: str) -> Any:
         """
-        Retrieves an item from the cache.
+        Retrieve a cache entry.
 
         Args:
-            key (str): The key for which the cache value is retrieved.
+            key: Unique key identifying the cache entry.
+            category: Cache category name.
+            version: Version string for invalidation.
 
         Returns:
-            None: Always returns None, simulating a cache miss.
+            None always, indicating a cache miss.
         """
         return None
 
-    def store(self, key, value):
+    def store(self, key: str, value: Any, category: str, version: str) -> None:
         """
-        Stores an item in the cache.
+        Store a value in the cache.
 
         Args:
-            key (str): The key under which the value is stored.
-            value (any): The value to be stored.
+            key: Unique key identifying the cache entry.
+            value: Object to store.
+            category: Cache category name.
+            version: Version string for invalidation.
         """
         pass
 
-    def clear(self):
+    def clear(self) -> None:
         """
-        Clears all items from the cache.
+        Remove all cache entries (no-op).
+
+        Args:
+            None
         """
         pass
 
-    def remove(self, key):
+    def remove(self, key: str) -> None:
         """
-        Remove a specific entry from the cache
+        Remove cache entries matching the given key (no-op).
+
+        Args:
+            key: Unique key identifying entries to remove.
         """
         pass
 
 
 class LocalFolderCache:
-    """
-    A cache that stores data as serialized objects in a local directory. Implements basic LRU (Least Recently Used)
-    cleanup to maintain the cache within a specified maximum size limit.
-    """
+    """LRU-style cache that stores pickled objects in a local directory."""
 
-    def __init__(self, path, max_size_gb):
+    def __init__(self, path: str, max_size_gb: float):
         """
-        Initializes the LocalFolderCache instance.
+        Initialize the LocalFolderCache.
 
         Args:
-            path (str): The filesystem path to the directory to be used for cache storage.
-            max_size_gb (float): The maximum size of the cache in gigabytes.
+            path: Directory path for storing cache files.
+            max_size_gb: Maximum total cache size in gigabytes.
         """
         self.path = path
-        self.max_size_bytes = (
-            max_size_gb * 1024 * 1024 * 1024
-        )  # Convert GB to bytes
+        self.max_size_bytes = int(max_size_gb * 1024 ** 3)
         os.makedirs(self.path, exist_ok=True)
 
-    def get(self, key):
+    def get(self, key: str, category: str, version: str) -> Any | None:
         """
-        Retrieves an item from the cache by its key, if it exists.
+        Retrieve a cached value.
 
         Args:
-            key (str): The key for which the cache value is retrieved.
+            key: Unique key identifying the cache entry.
+            category: Cache category name.
+            version: Version string for invalidation.
 
         Returns:
-            any: The value stored in the cache, or None if the key does not exist or an error occurs.
+            The cached object, or None if not found or on load error.
         """
-        file_path = os.path.join(self.path, key)
-        if os.path.exists(file_path):
-            try:
-                with open(file_path, "rb") as file:
-                    value = pickle.load(file)
-                return value
-            except (
-                pickle.UnpicklingError,
-                EOFError,
-                FileNotFoundError,
-                IOError,
-            ):
-                return None
-        return None
+        filepath = os.path.join(self.path, _compose_filename(key, category, version))
+        if not os.path.exists(filepath):
+            return None
+        try:
+            with open(filepath, "rb") as f:
+                return pickle.load(f)
+        except (pickle.UnpicklingError, EOFError, OSError):
+            return None
 
-    def store(self, key, value):
+    def store(self, key: str, value: Any, category: str, version: str) -> None:
         """
-        Stores an item in the cache under the specified key, managing the cache size to stay within limits.
+        Store a value in the cache under the given key/category/version.
 
         Args:
-            key (str): The key under which the value is stored.
-            value (any): The value to be stored.
+            key: Unique key identifying the cache entry.
+            value: Object to store.
+            category: Cache category name.
+            version: Version string for invalidation.
+
+        Notes:
+            If the serialized object exceeds the cache size limit, it will not be stored.
+            Before storing, stale files in the same category but different version are removed.
         """
-        file_path = os.path.join(self.path, key)
-        serialized_value = pickle.dumps(value)
-        value_size = len(serialized_value)
-        if value_size > self.max_size_bytes:
+        data = pickle.dumps(value)
+        if len(data) > self.max_size_bytes:
             return
-        with open(file_path, "wb") as file:
-            file.write(serialized_value)
-        self._cleanup()
 
-    def _cleanup(self):
-        """
-        Cleans up the cache directory to maintain it within the maximum size limit by removing the least
-        recently accessed files first. Called automatically everytime a new item is stored.
-        """
-        total_size = sum(
-            os.path.getsize(os.path.join(self.path, f))
-            for f in os.listdir(self.path)
-        )
-        if total_size > self.max_size_bytes:
-            files = sorted(
-                os.listdir(self.path),
-                key=lambda f: os.path.getatime(os.path.join(self.path, f)),
-                reverse=True,
-            )
-            while total_size > self.max_size_bytes and files:
-                file_to_remove = files.pop()
-                file_path = os.path.join(self.path, file_to_remove)
-                total_size -= os.path.getsize(file_path)
-                os.remove(file_path)
+        self._remove_stale(category, version)
 
-    def clear(self):
+        filepath = os.path.join(self.path, _compose_filename(key, category, version))
+        with open(filepath, "wb") as f:
+            f.write(data)
+
+        self._enforce_size_limit()
+
+    def clear(self) -> None:
         """
-        Clears the cache by removing the cache directory and all its contents.
+        Remove all cache files.
+
+        Args:
+            None
         """
         shutil.rmtree(self.path, ignore_errors=True)
+        os.makedirs(self.path, exist_ok=True)
 
-    def remove(self, key):
+    def remove(self, key: str) -> None:
         """
-        Remove a specific entry from the cache
+        Remove cache files matching the given key across categories and versions.
+
+        Args:
+            key: Unique key identifying entries to remove.
         """
-        file_path = os.path.join(self.path, key)
-        os.remove(file_path)
+        prefix = f"{key}__"
+        for fname in os.listdir(self.path):
+            if fname.startswith(prefix):
+                os.remove(os.path.join(self.path, fname))
+
+    def _remove_stale(self, category: str, allowed_version: str) -> None:
+        """
+        Delete files in the given category that do not match the allowed version.
+
+        Args:
+            category: Cache category name.
+            allowed_version: Version string to retain.
+        """
+        for fname in os.listdir(self.path):
+            parts = fname.split("__")
+            if len(parts) != 3 or not fname.endswith(".pkl"):
+                continue
+            _, cat, ver_ext = parts
+            version = ver_ext.rsplit(".", 1)[0]
+            if cat == category and version != allowed_version:
+                os.remove(os.path.join(self.path, fname))
+
+    def _enforce_size_limit(self) -> None:
+        """
+        Evict least-recently-used files until the cache size is under the configured limit.
+
+        Args:
+            None
+        """
+        files = os.listdir(self.path)
+        total = sum(os.path.getsize(os.path.join(self.path, f)) for f in files)
+        if total <= self.max_size_bytes:
+            return
+
+        files.sort(key=lambda f: os.path.getatime(os.path.join(self.path, f)))
+        while total > self.max_size_bytes and files:
+            oldest = files.pop(0)
+            path = os.path.join(self.path, oldest)
+            total -= os.path.getsize(path)
+            os.remove(path)

--- a/biolearn/data_library.py
+++ b/biolearn/data_library.py
@@ -868,6 +868,9 @@ class DataSource:
         "parser": "'parser' key is missing in item",
     }
 
+    CACHE_CATEGORY = "data_source"
+    CACHE_VERSION = "v1"
+
     def __init__(self, source_definition, cache=None):
         """
         Initializes the DataSource instance with configuration data and an optional cache mechanism.
@@ -917,13 +920,13 @@ class DataSource:
         if self.tags and "work_needed" in self.tags:
             self._show_work_needed_warning()
 
-        cached = self.cache.get(self.id)
-        if cached:
+        cached = self.cache.get(self.id, self.CACHE_CATEGORY, self.CACHE_VERSION)
+        if cached is not None:
             return cached
-        else:
-            data = self.parser.parse(self.path)
-            self.cache.store(self.id, data)
-            return data
+
+        data = self.parser.parse(self.path)
+        self.cache.store(self.id, data, self.CACHE_CATEGORY, self.CACHE_VERSION)
+        return data
 
     def __repr__(self):
         """

--- a/biolearn/test/test_cache.py
+++ b/biolearn/test/test_cache.py
@@ -1,99 +1,142 @@
 import os
 import shutil
-import pytest
 import time
+import pytest
+
 from biolearn.cache import LocalFolderCache
+
+CATEGORY_EXPR = "expr"
+CATEGORY_META = "meta"
+VERSION_V1 = "v1"
+VERSION_V2 = "v2"
 
 
 @pytest.fixture
-def cache():
-    cache_path = "test_cache"
-    max_size_gb = 0.000000954  # 1 KB for testing purposes
-    cache = LocalFolderCache(cache_path, max_size_gb)
-    yield cache
-    # Clean up the cache directory after each test
-    shutil.rmtree(cache_path, ignore_errors=True)
+def cache(tmp_path):
+    """Create an isolated LocalFolderCache per test."""
+    cache_path = tmp_path / "cache"
+    max_size_gb = 0.000000954  # 1 KB
+    c = LocalFolderCache(str(cache_path), max_size_gb)
+    yield c
+    # Cleanup handled by tmp_path fixture
 
 
 def test_store_and_get(cache):
-    cache.store("key1", "value1")
-    assert cache.get("key1") == "value1"
+    cache.store("key1", "value1", CATEGORY_EXPR, VERSION_V1)
+    assert cache.get("key1", CATEGORY_EXPR, VERSION_V1) == "value1"
 
 
 def test_get_nonexistent_key(cache):
-    assert cache.get("nonexistent_key") is None
+    assert cache.get("missing", CATEGORY_EXPR, VERSION_V1) is None
 
 
 def test_store_and_get_multiple_keys(cache):
-    cache.store("key1", "value1")
-    cache.store("key2", "value2")
-    assert cache.get("key1") == "value1"
-    assert cache.get("key2") == "value2"
+    cache.store("key1", "value1", CATEGORY_EXPR, VERSION_V1)
+    cache.store("key2", "value2", CATEGORY_EXPR, VERSION_V1)
+    assert cache.get("key1", CATEGORY_EXPR, VERSION_V1) == "value1"
+    assert cache.get("key2", CATEGORY_EXPR, VERSION_V1) == "value2"
 
 
 def test_cache_size_limit(cache):
-    # Store items exceeding the cache size limit
-    cache.store("key1", "a" * 500)  # 500 bytes
-    time.sleep(0.1)  # Ensure file timestamps are different
-    cache.store("key2", "b" * 800)  # 800 bytes
-    time.sleep(0.1)
-    cache.store("key3", "c" * 150)  # 150 bytes
-
-    # Check that the least recently used item (key1) is evicted
-    assert cache.get("key1") is None
-    assert cache.get("key2") == "b" * 800
-    assert cache.get("key3") == "c" * 150
+    cache.store("key1", "a" * 500, CATEGORY_EXPR, VERSION_V1)  # 500 B
+    time.sleep(0.01)
+    cache.store("key2", "b" * 800, CATEGORY_EXPR, VERSION_V1)  # 800 B
+    time.sleep(0.01)
+    cache.store("key3", "c" * 150, CATEGORY_EXPR, VERSION_V1)  # 150 B
+    # key1 should be evicted (LRU)
+    assert cache.get("key1", CATEGORY_EXPR, VERSION_V1) is None
+    assert cache.get("key2", CATEGORY_EXPR, VERSION_V1) == "b" * 800
+    assert cache.get("key3", CATEGORY_EXPR, VERSION_V1) == "c" * 150
 
 
 def test_lru_respects_get_calls(cache):
-    # Store items exceeding the cache size limit
-    cache.store("key1", "a" * 500)
-    time.sleep(0.1)  # Ensure file timestamps are different
-    cache.store("key2", "b" * 400)
-    time.sleep(0.1)
-    cache.get("key1")  # Ensure Key1 most recently used
-    time.sleep(0.1)
-    cache.store("key3", "c" * 150)
+    cache.store("key1", "a" * 500, CATEGORY_EXPR, VERSION_V1)
+    time.sleep(0.01)
+    cache.store("key2", "b" * 400, CATEGORY_EXPR, VERSION_V1)
+    time.sleep(0.01)
+    cache.get("key1", CATEGORY_EXPR, VERSION_V1)  # refresh key1
+    time.sleep(0.01)
+    cache.store("key3", "c" * 150, CATEGORY_EXPR, VERSION_V1)
 
-    # Check that the least recently used item (key1) is evicted
-    assert cache.get("key1") == "a" * 500
-    assert cache.get("key2") is None
-    assert cache.get("key3") == "c" * 150
+    assert cache.get("key1", CATEGORY_EXPR, VERSION_V1) == "a" * 500
+    assert cache.get("key2", CATEGORY_EXPR, VERSION_V1) is None
+    assert cache.get("key3", CATEGORY_EXPR, VERSION_V1) == "c" * 150
 
 
 def test_clear(cache):
-    cache.store("key1", "value1")
-    cache.store("key2", "value2")
+    cache.store("key1", "value1", CATEGORY_EXPR, VERSION_V1)
+    cache.store("key2", "value2", CATEGORY_EXPR, VERSION_V1)
     cache.clear()
-    assert cache.get("key1") is None
-    assert cache.get("key2") is None
+    assert cache.get("key1", CATEGORY_EXPR, VERSION_V1) is None
+    assert cache.get("key2", CATEGORY_EXPR, VERSION_V1) is None
 
 
 def test_store_item_larger_than_cache_size(cache):
-    # Store a small item in the cache
-    small_item = "small"
-    cache.store("small_key", small_item)
-    time.sleep(0.1)  # Ensure file timestamps are different
-
-    large_item = "x" * 2000  # 2000 bytes
-    cache.store("large_key", large_item)
-
-    assert cache.get("large_key") is None
-    assert cache.get("small_key") == small_item
+    cache.store("small_key", "small", CATEGORY_EXPR, VERSION_V1)
+    large_item = "x" * 2000  # 2000 B
+    cache.store("large_key", large_item, CATEGORY_EXPR, VERSION_V1)
+    assert cache.get("large_key", CATEGORY_EXPR, VERSION_V1) is None
+    assert cache.get("small_key", CATEGORY_EXPR, VERSION_V1) == "small"
 
 
 def test_remove_key(cache):
-    # Store multiple keys in the cache
-    cache.store("key1", "value1")
-    cache.store("key2", "value2")
-    cache.store("key3", "value3")
-
-    # Remove one key
+    cache.store("key1", "value1", CATEGORY_EXPR, VERSION_V1)
+    cache.store("key2", "value2", CATEGORY_EXPR, VERSION_V1)
+    cache.store("key3", "value3", CATEGORY_EXPR, VERSION_V1)
     cache.remove("key2")
+    assert cache.get("key2", CATEGORY_EXPR, VERSION_V1) is None
+    assert cache.get("key1", CATEGORY_EXPR, VERSION_V1) == "value1"
+    assert cache.get("key3", CATEGORY_EXPR, VERSION_V1) == "value3"
 
-    # Verify that the removed key is no longer in the cache
-    assert cache.get("key2") is None
+# ---------- New tests for versioning ----------
 
-    # Verify that the other keys are still in the cache
-    assert cache.get("key1") == "value1"
-    assert cache.get("key3") == "value3"
+def test_version_mismatch_returns_none(cache):
+    cache.store("k", "v", CATEGORY_EXPR, VERSION_V1)
+    assert cache.get("k", CATEGORY_EXPR, VERSION_V2) is None
+
+
+def test_category_mismatch_returns_none(cache):
+    cache.store("k", "v", CATEGORY_EXPR, VERSION_V1)
+    assert cache.get("k", CATEGORY_META, VERSION_V1) is None
+
+
+def test_filename_composition(cache):
+    cache.store("k", "v", CATEGORY_EXPR, VERSION_V1)
+    files = os.listdir(cache.path)
+    assert any(f.startswith("k__expr__v1") for f in files)
+
+
+def test_cleanup_removes_stale_files(cache):
+    # Manually create a stale file
+    stale_path = os.path.join(cache.path, "k__expr__v0.pkl")
+    with open(stale_path, "wb") as f:
+        f.write(b"old")
+    # Trigger cleanup via normal store
+    cache.store("fresh", "v", CATEGORY_EXPR, VERSION_V1)
+    assert "k__expr__v0.pkl" not in os.listdir(cache.path)
+
+
+def test_lru_still_works_with_versions(cache):
+    cache.store("k1", "a" * 500, CATEGORY_EXPR, VERSION_V1)
+    time.sleep(0.01)
+    cache.store("k2", "b" * 400, CATEGORY_EXPR, VERSION_V1)
+    time.sleep(0.01)
+    cache.get("k1", CATEGORY_EXPR, VERSION_V1)
+    time.sleep(0.01)
+    cache.store("k3", "c" * 150, CATEGORY_EXPR, VERSION_V1)
+    assert cache.get("k1", CATEGORY_EXPR, VERSION_V1) == "a" * 500
+    assert cache.get("k2", CATEGORY_EXPR, VERSION_V1) is None
+    assert cache.get("k3", CATEGORY_EXPR, VERSION_V1) == "c" * 150
+
+
+def test_mixed_categories_independent_versions(cache):
+    cache.store("k1", "expr_v1", CATEGORY_EXPR, VERSION_V1)
+    cache.store("k1", "meta_v1", CATEGORY_META, VERSION_V1)
+    # now bump expr version to v2
+    assert cache.get("k1", CATEGORY_EXPR, VERSION_V2) is None
+    assert cache.get("k1", CATEGORY_META, VERSION_V1) == "meta_v1"
+
+
+def test_no_default_version_argument(cache):
+    with pytest.raises(TypeError):
+        cache.get("x", CATEGORY_EXPR)  # missing version arg


### PR DESCRIPTION
Allows cached data to be invalidated by bumping a version number.
Supports multiple cache categories with separate versioning.