### PR TITLE
Fix #143: Improve GrimAge error messages for missing metadata

### DIFF
--- a/biolearn/model.py
+++ b/biolearn/model.py
@@ -850,8 +850,27 @@ class GrimageModel:
         )
 
     def predict(self, geo_data):
-        if "sex" not in geo_data.metadata or "age" not in geo_data.metadata:
-            raise ValueError("metadata must contain 'sex' and 'age' columns")
+        if "sex" not in geo_data.metadata:
+            raise ValueError(
+                "GrimAge requires 'sex' column in metadata. "
+                "If sex is unknown, you can predict it using the SexEstimation model:\n"
+                "  from biolearn.model_gallery import ModelGallery\n"
+                "  gallery = ModelGallery()\n"
+                "  sex_pred = gallery.get('SexEstimation').predict(your_data)\n"
+                "  # Then add sex to metadata based on predictions"
+            )
+
+        if "age" not in geo_data.metadata:
+            raise ValueError("GrimAge requires 'age' column in metadata (numeric age in years)")
+
+        # Check for NaN sex values
+        sex_values = geo_data.metadata["sex"]
+        if sex_values.isna().any():
+            nan_samples = sex_values[sex_values.isna()].index.tolist()
+            raise ValueError(
+                f"GrimAge cannot process samples with unknown sex: {nan_samples[:3]}.\n"
+                f"Either exclude these samples or predict sex using SexEstimation model."
+            )
 
         df = geo_data.dnam
 
@@ -920,6 +939,14 @@ class GrimageModel:
             .multiply(coefficients_series, axis=0)
             .sum()
         )
+
+        # Check for NaN results which indicate missing data
+        if result.isna().any():
+            nan_samples = result[result.isna()].index.tolist()
+            raise ValueError(
+                f"Missing methylation data for required CpG sites in samples: {nan_samples[:3]}. "
+                f"Ensure all required methylation sites are present in your data."
+            )
 
         return result
 

--- a/biolearn/model.py
+++ b/biolearn/model.py
@@ -872,6 +872,24 @@ class GrimageModel:
                 f"Either exclude these samples or predict sex using SexEstimation model."
             )
 
+        # Check for sample mismatch between methylation matrix and metadata
+        dnam_samples = set(geo_data.dnam.columns)
+        metadata_samples = set(geo_data.metadata.index)
+        missing_metadata = dnam_samples - metadata_samples
+        missing_dnam = metadata_samples - dnam_samples
+
+        if missing_metadata:
+            raise ValueError(
+                f"Methylation data contains samples without metadata: {list(missing_metadata)[:3]}.\n"
+                f"Ensure all samples in methylation matrix have corresponding metadata entries."
+            )
+
+        if missing_dnam:
+            raise ValueError(
+                f"Metadata contains samples without methylation data: {list(missing_dnam)[:3]}.\n"
+                f"Ensure all samples in metadata have corresponding methylation data."
+            )
+
         df = geo_data.dnam
 
         # Transposing metadata so that its structure aligns with dnam (columns as samples)

--- a/biolearn/model.py
+++ b/biolearn/model.py
@@ -861,7 +861,9 @@ class GrimageModel:
             )
 
         if "age" not in geo_data.metadata:
-            raise ValueError("GrimAge requires 'age' column in metadata (numeric age in years)")
+            raise ValueError(
+                "GrimAge requires 'age' column in metadata (numeric age in years)"
+            )
 
         # Check for NaN sex values
         sex_values = geo_data.metadata["sex"]

--- a/biolearn/test/test_grimage_missing_metadata.py
+++ b/biolearn/test/test_grimage_missing_metadata.py
@@ -64,3 +64,44 @@ def test_grimage_nan_sex_values():
     error_msg = str(exc_info.value)
     assert "cannot process samples with unknown sex" in error_msg
     assert "SexEstimation" in error_msg
+
+
+def test_grimage_sample_mismatch():
+    """Test that mismatched samples between methylation and metadata give clear error."""
+    sample_inputs = load_test_data_file("external/DNAmTestSet.csv")
+    sample_metadata = load_test_data_file("external/testset_metadata.csv")
+
+    # Remove one sample from metadata to create mismatch
+    mismatched_metadata = sample_metadata.drop(sample_metadata.index[0])
+    test_data = GeoData(mismatched_metadata, sample_inputs)
+
+    gallery = ModelGallery()
+    grimage_model = gallery.get('GrimAgeV2')
+
+    with pytest.raises(ValueError) as exc_info:
+        grimage_model.predict(test_data)
+
+    error_msg = str(exc_info.value)
+    assert "Methylation data contains samples without metadata" in error_msg
+    assert "Ensure all samples in methylation matrix have corresponding metadata" in error_msg
+
+
+def test_grimage_reverse_sample_mismatch():
+    """Test metadata samples without methylation data give clear error."""
+    sample_inputs = load_test_data_file("external/DNAmTestSet.csv")
+    sample_metadata = load_test_data_file("external/testset_metadata.csv")
+
+    # Add extra sample to metadata to create reverse mismatch
+    extra_metadata = sample_metadata.copy()
+    extra_metadata.loc['EXTRA_SAMPLE'] = {'age': 50, 'sex': 1}
+    test_data = GeoData(extra_metadata, sample_inputs)
+
+    gallery = ModelGallery()
+    grimage_model = gallery.get('GrimAgeV2')
+
+    with pytest.raises(ValueError) as exc_info:
+        grimage_model.predict(test_data)
+
+    error_msg = str(exc_info.value)
+    assert "Metadata contains samples without methylation data" in error_msg
+    assert "Ensure all samples in metadata have corresponding methylation" in error_msg

--- a/biolearn/test/test_grimage_missing_metadata.py
+++ b/biolearn/test/test_grimage_missing_metadata.py
@@ -1,0 +1,66 @@
+import pytest
+import pandas as pd
+import numpy as np
+from biolearn.model_gallery import ModelGallery
+from biolearn.data_library import GeoData
+from biolearn.util import load_test_data_file
+
+
+def test_grimage_missing_sex_column():
+    """Test that missing sex column gives helpful error message."""
+    sample_inputs = load_test_data_file("external/DNAmTestSet.csv")
+    sample_metadata = load_test_data_file("external/testset_metadata.csv")
+
+    # Remove sex column
+    metadata_no_sex = sample_metadata.drop(columns=['sex'])
+    test_data = GeoData(metadata_no_sex, sample_inputs)
+
+    gallery = ModelGallery()
+    grimage_model = gallery.get('GrimAgeV2')
+
+    with pytest.raises(ValueError) as exc_info:
+        grimage_model.predict(test_data)
+
+    error_msg = str(exc_info.value)
+    assert "GrimAge requires 'sex' column" in error_msg
+    assert "SexEstimation" in error_msg
+
+
+def test_grimage_missing_age_column():
+    """Test that missing age column gives clear error message."""
+    sample_inputs = load_test_data_file("external/DNAmTestSet.csv")
+    sample_metadata = load_test_data_file("external/testset_metadata.csv")
+
+    # Remove age column
+    metadata_no_age = sample_metadata.drop(columns=['age'])
+    test_data = GeoData(metadata_no_age, sample_inputs)
+
+    gallery = ModelGallery()
+    grimage_model = gallery.get('GrimAgeV2')
+
+    with pytest.raises(ValueError) as exc_info:
+        grimage_model.predict(test_data)
+
+    error_msg = str(exc_info.value)
+    assert "GrimAge requires 'age' column" in error_msg
+
+
+def test_grimage_nan_sex_values():
+    """Test that NaN sex values give helpful error message."""
+    sample_inputs = load_test_data_file("external/DNAmTestSet.csv")
+    sample_metadata = load_test_data_file("external/testset_metadata.csv")
+
+    # Set some sex values to NaN
+    test_metadata = sample_metadata.copy()
+    test_metadata.loc[test_metadata.index[0], 'sex'] = np.nan
+    test_data = GeoData(test_metadata, sample_inputs)
+
+    gallery = ModelGallery()
+    grimage_model = gallery.get('GrimAgeV2')
+
+    with pytest.raises(ValueError) as exc_info:
+        grimage_model.predict(test_data)
+
+    error_msg = str(exc_info.value)
+    assert "cannot process samples with unknown sex" in error_msg
+    assert "SexEstimation" in error_msg

--- a/biolearn/test/test_grimage_missing_metadata.py
+++ b/biolearn/test/test_grimage_missing_metadata.py
@@ -12,11 +12,11 @@ def test_grimage_missing_sex_column():
     sample_metadata = load_test_data_file("external/testset_metadata.csv")
 
     # Remove sex column
-    metadata_no_sex = sample_metadata.drop(columns=['sex'])
+    metadata_no_sex = sample_metadata.drop(columns=["sex"])
     test_data = GeoData(metadata_no_sex, sample_inputs)
 
     gallery = ModelGallery()
-    grimage_model = gallery.get('GrimAgeV2')
+    grimage_model = gallery.get("GrimAgeV2")
 
     with pytest.raises(ValueError) as exc_info:
         grimage_model.predict(test_data)
@@ -32,11 +32,11 @@ def test_grimage_missing_age_column():
     sample_metadata = load_test_data_file("external/testset_metadata.csv")
 
     # Remove age column
-    metadata_no_age = sample_metadata.drop(columns=['age'])
+    metadata_no_age = sample_metadata.drop(columns=["age"])
     test_data = GeoData(metadata_no_age, sample_inputs)
 
     gallery = ModelGallery()
-    grimage_model = gallery.get('GrimAgeV2')
+    grimage_model = gallery.get("GrimAgeV2")
 
     with pytest.raises(ValueError) as exc_info:
         grimage_model.predict(test_data)
@@ -52,11 +52,11 @@ def test_grimage_nan_sex_values():
 
     # Set some sex values to NaN
     test_metadata = sample_metadata.copy()
-    test_metadata.loc[test_metadata.index[0], 'sex'] = np.nan
+    test_metadata.loc[test_metadata.index[0], "sex"] = np.nan
     test_data = GeoData(test_metadata, sample_inputs)
 
     gallery = ModelGallery()
-    grimage_model = gallery.get('GrimAgeV2')
+    grimage_model = gallery.get("GrimAgeV2")
 
     with pytest.raises(ValueError) as exc_info:
         grimage_model.predict(test_data)
@@ -76,14 +76,17 @@ def test_grimage_sample_mismatch():
     test_data = GeoData(mismatched_metadata, sample_inputs)
 
     gallery = ModelGallery()
-    grimage_model = gallery.get('GrimAgeV2')
+    grimage_model = gallery.get("GrimAgeV2")
 
     with pytest.raises(ValueError) as exc_info:
         grimage_model.predict(test_data)
 
     error_msg = str(exc_info.value)
     assert "Methylation data contains samples without metadata" in error_msg
-    assert "Ensure all samples in methylation matrix have corresponding metadata" in error_msg
+    assert (
+        "Ensure all samples in methylation matrix have corresponding metadata"
+        in error_msg
+    )
 
 
 def test_grimage_reverse_sample_mismatch():
@@ -93,15 +96,18 @@ def test_grimage_reverse_sample_mismatch():
 
     # Add extra sample to metadata to create reverse mismatch
     extra_metadata = sample_metadata.copy()
-    extra_metadata.loc['EXTRA_SAMPLE'] = {'age': 50, 'sex': 1}
+    extra_metadata.loc["EXTRA_SAMPLE"] = {"age": 50, "sex": 1}
     test_data = GeoData(extra_metadata, sample_inputs)
 
     gallery = ModelGallery()
-    grimage_model = gallery.get('GrimAgeV2')
+    grimage_model = gallery.get("GrimAgeV2")
 
     with pytest.raises(ValueError) as exc_info:
         grimage_model.predict(test_data)
 
     error_msg = str(exc_info.value)
     assert "Metadata contains samples without methylation data" in error_msg
-    assert "Ensure all samples in metadata have corresponding methylation" in error_msg
+    assert (
+        "Ensure all samples in metadata have corresponding methylation"
+        in error_msg
+    )


### PR DESCRIPTION
Replace cryptic "Input X contains NaN" errors with clear, actionable guidance that helps users resolve missing metadata issues.

Changes:
- Add specific validation for missing age/sex columns
- Detect NaN sex values and suggest SexEstimation model (Seths awesomeness)
- Improve error messages for missing methylation data
- Guide users to existing biolearn tools for solutions

Fixes bio-learn/biolearn#143