### PR TITLE
feat: Add support for third-party API models with Hurdle implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ notebooks/
 biolearn/test/data/external/
 
 .env
+
+# API credentials and sensitive files
+*_api_key*
+*_credentials*
+HurdleTesting.ipynb
+**/hurdle_credentials.json
+**/.biolearn/

--- a/biolearn/data/Hurdle_CpGs.csv.example
+++ b/biolearn/data/Hurdle_CpGs.csv.example
@@ -1,0 +1,10 @@
+ProbeID
+cg00000029
+cg00000321
+cg00000714
+cg00001793
+cg00002028
+# Add more CpG sites here
+# This is a placeholder file
+# Replace with actual Hurdle CpG sites list
+# Contact Hurdle Bio for the complete list

--- a/biolearn/model.py
+++ b/biolearn/model.py
@@ -3,6 +3,10 @@ import cvxpy as cp
 import numpy as np
 import pandas as pd
 from sklearn.linear_model import LinearRegression
+import requests
+import io
+import warnings
+from typing import Optional, Dict, Any, Union
 
 from biolearn.data_library import GeoData
 from biolearn.dunedin_pace import dunedin_pace_normalization
@@ -599,6 +603,22 @@ model_definitions = {
             "file": "Bocklandt.csv",
         },
     },
+    "HurdleInflammage": {
+        "year": 2024,
+        "species": "Human",
+        "tissue": "Blood",
+        "source": "https://hurdle.bio/our-science/",
+        "output": "Inflammation Age (Years)",
+        "model": {
+            "type": "HurdleAPIModel",
+            "use_production": False,
+            "default_imputation": "none",
+        },
+        "usage": {
+            "commercial": "Contact Hurdle Bio for licensing",
+            "non-commercial": "Register at https://dashboard.sandbox.hurdle.bio/register/partner",
+        },
+    },
 }
 
 
@@ -1043,6 +1063,166 @@ class SexEstimationModel:
 
     def methylation_sites(self):
         return list(self.coefficients.index)
+
+
+class HurdleAPIModel:
+    """
+    Hurdle Bio Inflammage model via API.
+
+    Requires API credentials from https://dashboard.sandbox.hurdle.bio/register/partner
+    """
+
+    def __init__(self, api_key: Optional[str] = None, use_production: bool = False, **details):
+        self.details = details
+        self.api_key = api_key or os.environ.get('HURDLE_API_KEY')
+
+        if not self.api_key:
+            raise ValueError(
+                "API key required. Either pass api_key parameter or set HURDLE_API_KEY environment variable.\n"
+                "Get your API key at: https://dashboard.sandbox.hurdle.bio/register/partner"
+            )
+
+        base_url = "https://api.hurdle.bio" if use_production else "https://api.sandbox.hurdle.bio"
+        self.api_endpoint = f"{base_url}/predict/v1/"
+        self._consent_given = False
+
+        # Load required CpG sites
+        try:
+            cpg_file = get_data_file("Hurdle_CpGs.csv")
+            self.required_cpgs = pd.read_csv(cpg_file, encoding='ISO-8859-1')['ProbeID'].tolist()
+        except:
+            self.required_cpgs = None
+            warnings.warn("Hurdle CpG sites file not found. Will use all available CpG sites.")
+
+    @classmethod
+    def from_definition(cls, clock_definition):
+        model_def = clock_definition["model"]
+        return cls(
+            use_production=model_def.get("use_production", False),
+            **{k: v for k, v in clock_definition.items() if k != "model"}
+        )
+
+    def _get_consent(self):
+        if not self._consent_given:
+            print("\nWARNING: This will send methylation data to Hurdle Bio's servers.")
+            print("Please ensure you have permission to share this data with third parties.")
+            response = input("Do you consent to send this data? (yes/no): ").lower().strip()
+
+            if response != 'yes':
+                raise ValueError("User consent required to send data to external API")
+
+            self._consent_given = True
+
+    def predict(self, data: Union[pd.DataFrame, GeoData]) -> pd.Series:
+        self._get_consent()
+
+        # Extract methylation data
+        if isinstance(data, GeoData):
+            dnam = data.dnam
+            metadata = data.metadata
+        else:
+            dnam = data
+            metadata = pd.DataFrame(index=dnam.columns)
+
+        # Filter and impute CpG sites
+        if self.required_cpgs:
+            missing_cpgs = set(self.required_cpgs) - set(dnam.index)
+            available_cpgs = [cpg for cpg in self.required_cpgs if cpg in dnam.index]
+
+            if not available_cpgs:
+                raise ValueError("No required CpG sites found in data")
+
+            # Use available sites and impute missing ones with 0.5
+            filtered_dnam = dnam.loc[available_cpgs]
+
+            if missing_cpgs:
+                warnings.warn(f"Missing {len(missing_cpgs)} required CpG sites. Imputing with 0.5")
+                missing_df = pd.DataFrame(
+                    0.5,
+                    index=list(missing_cpgs),
+                    columns=dnam.columns
+                )
+                filtered_dnam = pd.concat([filtered_dnam, missing_df])
+        else:
+            filtered_dnam = dnam
+
+        # Round values
+        filtered_dnam = filtered_dnam.round(3)
+
+        try:
+            # Get presigned URL
+            headers = {'x-api-key': self.api_key}
+            response = requests.post(
+                f"{self.api_endpoint}upload_link",
+                json={'fileType': 'beta_matrix'},
+                headers=headers
+            )
+
+            if response.status_code != 200:
+                raise Exception(f"Failed to get upload URL: {response.status_code} - {response.text}")
+
+            upload_info = response.json()
+
+            # Upload beta matrix
+            csv_buffer = io.StringIO()
+            filtered_dnam.to_csv(csv_buffer)
+            csv_buffer.seek(0)
+
+            upload_response = requests.put(
+                upload_info['uploadUrl'],
+                data=csv_buffer.getvalue().encode('utf-8')
+            )
+
+            if upload_response.status_code != 200:
+                raise Exception(f"Failed to upload data: {upload_response.status_code}")
+
+            # Prepare metadata
+            meta_list = []
+            for sample_id in filtered_dnam.columns:
+                sample_meta = {
+                    "barcode": sample_id,
+                    "tissue": "whole_blood"
+                }
+
+                if sample_id in metadata.index:
+                    row = metadata.loc[sample_id]
+                    if 'age' in row:
+                        sample_meta['chronologicalAge'] = float(row['age'])
+                    if 'sex' in row:
+                        sex_value = row['sex']
+                        sample_meta['sex'] = 'f' if sex_value in [1, 'f', 'F', 'female'] else 'm'
+
+                meta_list.append(sample_meta)
+
+            # Get predictions
+            prediction_request = {
+                'requestId': upload_info['requestId'],
+                'biomarker': 'inflammage',
+                'arrayType': 'hurdle',
+                'metadata': meta_list
+            }
+
+            pred_response = requests.post(
+                self.api_endpoint,
+                json=prediction_request,
+                headers=headers
+            )
+
+            if pred_response.status_code != 200:
+                raise Exception(f"Prediction failed: {pred_response.status_code} - {pred_response.text}")
+
+            # Extract predictions
+            results = pred_response.json()
+            predictions = {}
+            for item in results.get('data', []):
+                predictions[item['barcode']] = float(item['prediction'])
+
+            return pd.Series(predictions, name='inflammage')
+
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Network error: {str(e)}")
+        except Exception as e:
+            raise Exception(f"API error: {str(e)}")
 
 
 class ImputationDecorator:

--- a/biolearn/model_gallery.py
+++ b/biolearn/model_gallery.py
@@ -7,6 +7,7 @@ from biolearn.model import (
     SexEstimationModel,
     ImputationDecorator,
     DeconvolutionModel,
+    HurdleAPIModel,
 )
 from biolearn.imputation import (
     hybrid_impute,
@@ -27,6 +28,7 @@ class ModelGallery:
         "GrimageModel": GrimageModel.from_definition,
         "SexEstimationModel": SexEstimationModel.from_definition,
         "DeconvolutionModel": DeconvolutionModel.from_definition,
+        "HurdleAPIModel": HurdleAPIModel.from_definition,
     }
 
     def __init__(self, models=model_definitions):

--- a/biolearn/test/test_hurdle_model.py
+++ b/biolearn/test/test_hurdle_model.py
@@ -1,0 +1,139 @@
+"""
+Test for HurdleAPIModel
+"""
+
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import Mock, patch, MagicMock
+import os
+
+from biolearn.model import HurdleAPIModel
+from biolearn.model_gallery import ModelGallery
+
+
+class TestHurdleAPIModel:
+    """Test the HurdleAPIModel class."""
+
+    def test_init_without_api_key(self):
+        """Test that initialization fails without API key."""
+        with pytest.raises(ValueError, match="API key required"):
+            HurdleAPIModel()
+
+    def test_init_with_api_key(self):
+        """Test initialization with API key."""
+        model = HurdleAPIModel(api_key="test_key")
+        assert model.api_key == "test_key"
+        assert "sandbox" in model.api_endpoint
+
+    @patch.dict(os.environ, {"HURDLE_API_KEY": "env_test_key"})
+    def test_init_with_env_key(self):
+        """Test initialization with environment variable."""
+        model = HurdleAPIModel()
+        assert model.api_key == "env_test_key"
+
+    def test_production_endpoint(self):
+        """Test production endpoint selection."""
+        model = HurdleAPIModel(api_key="test_key", use_production=True)
+        assert "sandbox" not in model.api_endpoint
+        assert "api.hurdle.bio" in model.api_endpoint
+
+    @patch('builtins.input', return_value='no')
+    def test_consent_denied(self):
+        """Test that prediction fails when consent is denied."""
+        model = HurdleAPIModel(api_key="test_key")
+        data = pd.DataFrame(np.random.rand(100, 5))
+
+        with pytest.raises(ValueError, match="User consent required"):
+            model.predict(data)
+
+    @patch('builtins.input', return_value='yes')
+    @patch('requests.post')
+    @patch('requests.put')
+    def test_predict_success(self, mock_put, mock_post, mock_input):
+        """Test successful prediction workflow."""
+        # Setup model
+        model = HurdleAPIModel(api_key="test_key")
+
+        # Mock API responses
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.side_effect = [
+            {
+                'uploadUrl': 'https://example.com/upload',
+                'requestId': 'test-request-123'
+            },
+            {
+                'data': [
+                    {'barcode': 'sample_0', 'prediction': '35.5'},
+                    {'barcode': 'sample_1', 'prediction': '42.3'},
+                ]
+            }
+        ]
+
+        mock_put.return_value.status_code = 200
+
+        # Create test data
+        data = pd.DataFrame(
+            np.random.rand(100, 2),
+            columns=['sample_0', 'sample_1']
+        )
+
+        # Make predictions
+        predictions = model.predict(data)
+
+        assert isinstance(predictions, pd.Series)
+        assert len(predictions) == 2
+        assert predictions['sample_0'] == 35.5
+        assert predictions['sample_1'] == 42.3
+
+    @patch('builtins.input', return_value='yes')
+    @patch('requests.post')
+    def test_api_error_handling(self, mock_post, mock_input):
+        """Test API error handling."""
+        model = HurdleAPIModel(api_key="test_key")
+
+        # Mock failed API response
+        mock_post.return_value.status_code = 401
+        mock_post.return_value.text = "Unauthorized"
+
+        data = pd.DataFrame(np.random.rand(100, 2))
+
+        with pytest.raises(Exception, match="Failed to get upload URL: 401"):
+            model.predict(data)
+
+    def test_model_gallery_integration(self):
+        """Test that HurdleAPIModel is available in ModelGallery."""
+        gallery = ModelGallery()
+
+        # Check that model is in definitions
+        assert "HurdleInflammage" in gallery.model_definitions
+
+        # Test loading with API key
+        with patch.dict(os.environ, {"HURDLE_API_KEY": "test_key"}):
+            model = gallery.get("HurdleInflammage")
+            assert isinstance(model, HurdleAPIModel)
+
+    @patch('builtins.input', return_value='yes')
+    def test_consent_only_asked_once(self, mock_input):
+        """Test that consent is only requested once."""
+        model = HurdleAPIModel(api_key="test_key")
+
+        # Mock successful API calls
+        with patch('requests.post') as mock_post, patch('requests.put') as mock_put:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.side_effect = [
+                {'uploadUrl': 'url', 'requestId': 'id'},
+                {'data': [{'barcode': 'sample', 'prediction': '40'}]}
+            ] * 2  # For two calls
+            mock_put.return_value.status_code = 200
+
+            data = pd.DataFrame(np.random.rand(100, 1), columns=['sample'])
+
+            # First prediction
+            model.predict(data)
+
+            # Second prediction should not ask for consent again
+            model.predict(data)
+
+            # Input should only be called once
+            assert mock_input.call_count == 1

--- a/docs/hurdle_api_guide.md
+++ b/docs/hurdle_api_guide.md
@@ -1,0 +1,132 @@
+# Using Hurdle's Inflammage Model in Biolearn
+
+## Quick Start
+
+1. **Get API Credentials**
+   - Register at: https://dashboard.sandbox.hurdle.bio/register/partner
+   - Save your API key securely
+
+2. **Set Up Your API Key**
+   ```bash
+   export HURDLE_API_KEY="your_api_key_here"
+   ```
+
+3. **Use the Model**
+   ```python
+   from biolearn.model_gallery import ModelGallery
+   
+   gallery = ModelGallery()
+   model = gallery.get("HurdleInflammage")
+   
+   # Make predictions
+   predictions = model.predict(methylation_data)
+   ```
+
+## Important Privacy Notice
+
+⚠️ **Data Privacy Warning**: Using this model will send your methylation data to Hurdle Bio's servers. You will be asked for explicit consent before any data is transmitted. Ensure you have permission to share genomic data with third parties.
+
+## Detailed Setup
+
+### Getting Your API Key
+
+1. Visit https://dashboard.sandbox.hurdle.bio/register/partner
+2. Create an account
+3. Navigate to API Keys section
+4. Generate a new API key
+5. Store it securely (never commit to version control)
+
+### Setting Your API Key
+
+**Option 1: Environment Variable (Recommended)**
+```bash
+export HURDLE_API_KEY="your_api_key_here"
+```
+
+**Option 2: Direct Input**
+```python
+from biolearn.model import HurdleAPIModel
+
+model = HurdleAPIModel(api_key="your_api_key_here")
+```
+
+## Usage Examples
+
+### Basic Usage
+```python
+from biolearn.model_gallery import ModelGallery
+from biolearn.data_library import DataLibrary
+
+# Load data
+data = DataLibrary().get("YourDataset").load()
+
+# Get model
+gallery = ModelGallery()
+model = gallery.get("HurdleInflammage")
+
+# Make predictions (you'll be asked for consent)
+predictions = model.predict(data.dnam)
+```
+
+### With Metadata
+```python
+# If your data includes age and sex information
+# The model will use this for more accurate predictions
+predictions = model.predict(data)  # Uses both dnam and metadata
+```
+
+## Troubleshooting
+
+### Common Errors
+
+**"API key required"**
+- Set your API key using one of the methods above
+- Verify the key is correct
+
+**"Failed to get upload URL: 401"**
+- Your API key may be invalid or expired
+- Check you're using the correct environment (sandbox vs production)
+
+**"No required CpG sites found in data"**
+- Your methylation data doesn't contain the CpG sites Hurdle requires
+- Contact Hurdle Bio for their required CpG sites list
+
+**Network Errors**
+- Check your internet connection
+- Verify firewall settings allow HTTPS connections to hurdle.bio
+
+## Data Requirements
+
+- **Input**: DNA methylation beta values (0-1 range)
+- **Format**: Pandas DataFrame with CpG sites as rows, samples as columns
+- **Tissue**: Blood samples recommended
+- **Optional**: Age and sex metadata improve accuracy
+
+## Sandbox vs Production
+
+By default, the model uses Hurdle's sandbox environment for testing:
+
+```python
+# Sandbox (default)
+model = gallery.get("HurdleInflammage")
+
+# Production (requires production API key)
+model = HurdleAPIModel(api_key="prod_key", use_production=True)
+```
+
+## Best Practices
+
+1. **Test First**: Use sandbox environment before production
+2. **Batch Processing**: For large datasets, process in smaller batches
+3. **Error Handling**: Always wrap API calls in try-except blocks
+4. **Data Security**: Ensure you have consent to share genomic data
+
+## Support
+
+- **Biolearn Issues**: Open an issue on the biolearn GitHub repository
+- **API Access**: Contact Hurdle Bio support
+- **Commercial Use**: Contact Hurdle Bio for licensing
+
+## Example Script
+
+See `examples/hurdle_api_example.py` for a complete working example.

--- a/examples/hurdle_api_example.py
+++ b/examples/hurdle_api_example.py
@@ -1,0 +1,64 @@
+"""
+Hurdle Inflammage API Example
+=============================
+
+This example shows how to use Hurdle Bio's Inflammage model through their API.
+"""
+
+import os
+import pandas as pd
+from biolearn.model_gallery import ModelGallery
+from biolearn.data_library import DataLibrary
+
+# Step 1: Set up your API key
+# Get your API key from: https://dashboard.sandbox.hurdle.bio/register/partner
+# Then either:
+# - Set environment variable: export HURDLE_API_KEY="your_key_here"
+# - Or pass directly to the model (shown below)
+
+# Step 2: Load some methylation data
+print("Loading sample data...")
+data = DataLibrary().get("BoAChallengeData").load()
+
+# Use a small subset for this example
+sample_data = data.dnam.iloc[:, :5]  # First 5 samples
+print(f"Using {sample_data.shape[1]} samples")
+
+# Step 3: Initialize the model
+gallery = ModelGallery()
+
+# If you have your API key in environment variable:
+# model = gallery.get("HurdleInflammage")
+
+# Or provide it directly:
+api_key = input("Enter your Hurdle API key: ").strip()
+model = gallery.get("HurdleInflammage")
+model.api_key = api_key
+
+# Step 4: Make predictions
+# Note: You will be asked for consent before data is sent
+print("\nMaking predictions...")
+try:
+    predictions = model.predict(sample_data)
+
+    print("\nResults:")
+    for sample, age in predictions.items():
+        print(f"{sample}: {age:.1f} years")
+
+except ValueError as e:
+    print(f"Error: {e}")
+except Exception as e:
+    print(f"API Error: {e}")
+
+# Optional: If you have metadata with chronological ages
+if hasattr(data, 'metadata') and 'age' in data.metadata.columns:
+    # Compare with chronological age
+    chrono_ages = data.metadata.loc[predictions.index, 'age']
+
+    print("\nAge Acceleration:")
+    for sample in predictions.index:
+        if sample in chrono_ages.index:
+            inflamm_age = predictions[sample]
+            chrono_age = chrono_ages[sample]
+            delta = inflamm_age - chrono_age
+            print(f"{sample}: {delta:+.1f} years")


### PR DESCRIPTION
## Description

This PR introduces a minimal framework for integrating third-party API models into biolearn, with Hurdle Bio's Inflammage model as the first implementation.

## Key Changes

- Add  class to  for API-based predictions
- Integrate  into  for consistent usage
- Implement privacy-first approach with explicit user consent before sending data
- Add automatic imputation for missing CpG sites (uses 0.5 for missing values)
- Include comprehensive error handling with user-friendly messages

## Security & Privacy Features

- API keys managed via environment variables () or direct input
- Explicit consent required before sending data to external servers
- Updated  to exclude credential files
- Clear warnings about third-party data sharing

## Documentation

- User guide in  with setup instructions
- Working example in 
- Placeholder file for Hurdle CpG sites list

## Testing

- Comprehensive test suite in 
- Mock API calls to avoid requiring credentials in tests
- Tests cover consent flow, error handling, and API integration

## Usage Example

```python
# Set API key
export HURDLE_API_KEY="your_key"

# Use the model
from biolearn.model_gallery import ModelGallery

gallery = ModelGallery()
model = gallery.get("HurdleInflammage")
predictions = model.predict(methylation_data)
```

## Design Decisions

1. **Minimal Impact**: Added only ~160 lines to existing files, no new modules
2. **User-Friendly**: Clear error messages and setup instructions
3. **Privacy-First**: Explicit consent required before any data transmission
4. **Robust Error Handling**: Specific messages for each failure type

This implementation provides a foundation for future API model integrations while maintaining the simplicity and usability of biolearn.

Fixes #[issue_number] (if applicable)