### PR TITLE
Remove restriction on metadata without dnam

### DIFF
--- a/biolearn/model.py
+++ b/biolearn/model.py
@@ -900,18 +900,11 @@ class GrimageModel:
         dnam_samples = set(geo_data.dnam.columns)
         metadata_samples = set(geo_data.metadata.index)
         missing_metadata = dnam_samples - metadata_samples
-        missing_dnam = metadata_samples - dnam_samples
 
         if missing_metadata:
             raise ValueError(
                 f"Methylation data contains samples without metadata: {list(missing_metadata)[:3]}.\n"
                 f"Ensure all samples in methylation matrix have corresponding metadata entries."
-            )
-
-        if missing_dnam:
-            raise ValueError(
-                f"Metadata contains samples without methylation data: {list(missing_dnam)[:3]}.\n"
-                f"Ensure all samples in metadata have corresponding methylation data."
             )
 
         df = geo_data.dnam

--- a/biolearn/test/test_grimage_missing_metadata.py
+++ b/biolearn/test/test_grimage_missing_metadata.py
@@ -75,23 +75,3 @@ def test_grimage_sample_mismatch():
         "Ensure all samples in methylation matrix have corresponding metadata"
         in error_msg
     )
-
-
-def test_grimage_reverse_sample_mismatch():
-    """Test metadata samples without methylation data give clear error."""
-    test_data = get_test_data()
-    # Remove one sample from dnam to create mismatch
-    test_data.dnam = test_data.dnam.iloc[:, 1:]
-
-    gallery = ModelGallery()
-    grimage_model = gallery.get("GrimAgeV2")
-
-    with pytest.raises(ValueError) as exc_info:
-        grimage_model.predict(test_data)
-
-    error_msg = str(exc_info.value)
-    assert "Metadata contains samples without methylation data" in error_msg
-    assert (
-        "Ensure all samples in metadata have corresponding methylation"
-        in error_msg
-    )


### PR DESCRIPTION
This removes the restriction from GrimAge that metadata entries are not allowed that don't have matching dnam entries. Reasoning 
1. Extra metadata does not break grimage
2. We currently have one dataset (the challenge data) the has proteomic data entries with metadata that don't have matching methylation data