### PR TITLE
fix(docs): preserve images across incremental builds

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,9 +47,6 @@ generate_dynamic_content:
 	python generate.py
 
 html:	sym_links generate_dynamic_content
-	# These two lines make the build a bit more lengthy, and the
-	# the embedding of images more robust
-	rm -rf $(BUILDDIR)/html/_images
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	touch $(BUILDDIR)/html/.nojekyll
 	@echo
@@ -57,5 +54,5 @@ html:	sym_links generate_dynamic_content
 
 deploy: html
 	# Assuming the docs repo is cloned in the same repo as biolearn is this will update the site
-	rsync -av --delete --exclude .git/ _build/html/ $(GH_PAGES_REPO)
-	cd $(GH_PAGES_REPO) && git add . && git commit -m "Automation Updated documentation" && git push
+	rsync -av --delete --exclude .git/ _build/html/ "$(GH_PAGES_REPO)"
+	cd "$(GH_PAGES_REPO)" && git add . && git commit -m "Automation Updated documentation" && git push


### PR DESCRIPTION
## Summary
- Remove `rm -rf _build/html/_images` which deleted images before each build
- Sphinx-gallery skips unchanged examples, but cached doctrees prevented image re-copying
- Also quote `$(GH_PAGES_REPO)` for paths with spaces

## Test plan
- [x] Run `make clean && make html` (first build)
- [x] Run `make html` again (second build)
- [x] Verify images persist (34 images vs 2 before fix)