### PR TITLE
Improve test data generation and download progress

### DIFF
--- a/biolearn/data_library.py
+++ b/biolearn/data_library.py
@@ -7,10 +7,6 @@ import gzip
 import shutil
 import os
 import math
-import matplotlib.pyplot as plt
-import seaborn as sns
-
-
 from biolearn.util import cached_download, get_data_file
 from biolearn.defaults import default_cache
 from biolearn.cache import NoCache


### PR DESCRIPTION
 ## Summary
  This PR improves test data generation by downloading the GEO series matrix directly with progress output and more robust error handling. It also upgrades the download helper to support resumable downloads, progress reporting, and forced re-downloads.

  ## Changes
  - Use `cached_download` with progress output in the test data generator.
  - Parse GEO metadata directly and limit the test dataset to 10 samples without `DataSource`.
  - Handle corrupted cached downloads by retrying with a forced re-download.
  - Enhance `cached_download` with `.part` files, HTTP range resume, and optional progress output.
  - Remove unused plotting imports.