### PR TITLE
Fix PhenoAge final-transform constants in hematology.py (~2 year error)

### DIFF
--- a/biolearn/hematology.py
+++ b/biolearn/hematology.py
@@ -22,7 +22,7 @@ def phenotypic_age(df):
 
     constant = -19.9067
     gamma = 0.0077
-    cs = [141.50225, -0.00553, 0.090165]
+    cs = [141.50225, -0.0055305, 0.09165]
 
     # Vectorized calculation - no DataFrame modifications
     pheno = (


### PR DESCRIPTION
The two constants in `cs` used to convert the mortality score into phenotypic age in `biolearn/hematology.py` have transposed/rounded digits compared to the original Levine 2018 values. This shifts the calculated PhenoAge by approximately **2 years**.

## The bug

```python
# Before (incorrect):
cs = [141.50225, -0.00553, 0.090165]

# After (correct):
cs = [141.50225, -0.0055305, 0.09165]
```

Two issues:
1. `-0.00553` should be `-0.0055305` (missing trailing digits)
2. `0.090165` should be `0.09165` (transposition of the last two digits)

## Verification

The corrected values match:
- The canonical **BioAge R package** ([dayoonkwon/BioAge](https://github.com/dayoonkwon/BioAge), `phenoage_calc.R` line: `dat$phenoage0 = ((log(-.0055305 * (log(1 - m_orig))) / .09165) + 141.50225)`)
- The **Cramer/Lustgarten PhenoAge spreadsheet** ([DNAmPhenoAge_gen.xls](https://michaellustgarten.com/wp-content/uploads/2021/10/3ba41-dnamphenoage_gen-1.xls))

### Example

Inputs (SI units): albumin=50 g/L, creatinine=75.14 µmol/L, glucose=4.44 mmol/L, ln(CRP)=-4.20, lymphocyte=40%, MCV=88 fL, RDW=12%, ALP=45 U/L, WBC=4.2, age=47

| | Linear combination | Mortality score | PhenoAge |
|---|---|---|---|
| Spreadsheet | -10.4638 | 0.005615 | **28.28** |
| Old code | -10.4638 | 0.005615 | **26.41** |
| Fixed code | -10.4638 | 0.005615 | **28.28** ✓ |

The intermediate values (linear combination and mortality score) are unaffected — only the final transform step was wrong.

## Related

Same fix submitted to [ajsteele/bioage](https://github.com/ajsteele/bioage/pull/8) (JavaScript implementation).