### PR TITLE
fix: handle read-only arrays in DunedinPACE quantile normalization (#195)

### DIFF
--- a/biolearn/dunedin_pace.py
+++ b/biolearn/dunedin_pace.py
@@ -50,6 +50,11 @@ def quantile_normalize_using_target(data, target_values):
     """
     Apply quantile normalization on data using target values.
     """
+    # Copy to a writable float array. Inputs coming from ``DataFrame.values``
+    # can be read-only (e.g. pandas copy-on-write in pandas >= 3.0), which
+    # would otherwise raise "assignment destination is read-only" on the
+    # in-place updates below.
+    data = np.array(data, dtype=float)
     sorted_target = np.sort(target_values)
 
     for _, column_data in enumerate(data.T):

--- a/biolearn/dunedin_pace.py
+++ b/biolearn/dunedin_pace.py
@@ -50,10 +50,8 @@ def quantile_normalize_using_target(data, target_values):
     """
     Apply quantile normalization on data using target values.
     """
-    # Copy to a writable float array. Inputs coming from ``DataFrame.values``
-    # can be read-only (e.g. pandas copy-on-write in pandas >= 3.0), which
-    # would otherwise raise "assignment destination is read-only" on the
-    # in-place updates below.
+    # Writable float copy: DataFrame.values can be read-only under pandas>=3.0
+    # copy-on-write, which would break the in-place updates below.
     data = np.array(data, dtype=float)
     sorted_target = np.sort(target_values)
 

--- a/biolearn/test/test_dunedin_pace.py
+++ b/biolearn/test/test_dunedin_pace.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pandas as pd
+
+from biolearn.dunedin_pace import quantile_normalize_using_target
+
+
+def _target():
+    return list(np.linspace(0.0, 1.0, 10))
+
+
+def test_quantile_normalize_accepts_read_only_array():
+    # Arrays from DataFrame.values can be read-only (e.g. pandas
+    # copy-on-write in pandas >= 3.0). Normalization must not fail with
+    # "assignment destination is read-only". See issue #195.
+    data = pd.DataFrame(np.random.rand(10, 3)).values
+    data.flags.writeable = False
+
+    result = quantile_normalize_using_target(data, _target())
+
+    assert result.shape == (10, 3)
+
+
+def test_quantile_normalize_does_not_mutate_input():
+    data = pd.DataFrame(np.random.rand(10, 3)).values
+    original = data.copy()
+
+    quantile_normalize_using_target(data, _target())
+
+    np.testing.assert_array_equal(data, original)
+
+
+def test_quantile_normalize_maps_values_onto_target_distribution():
+    target = _target()
+    data = pd.DataFrame(np.random.rand(10, 3)).values
+
+    result = quantile_normalize_using_target(data, target)
+
+    sorted_target = np.sort(target)
+    midpoints = 0.5 * (sorted_target[:-1] + sorted_target[1:])
+    allowed = np.round(np.concatenate([sorted_target, midpoints]), 6)
+    assert np.all(np.isin(np.round(result, 6), allowed))


### PR DESCRIPTION
## Summary

Fixes #195.

`DunedinPACE.predict` raises `ValueError: assignment destination is read-only` during quantile normalization:

```
File ".../biolearn/dunedin_pace.py", line 61, in quantile_normalize_using_target
    column_data[has_decimal_above_0_4] = 0.5 * (
ValueError: assignment destination is read-only
```

### Root cause

`quantile_normalize_using_target` mutates its input array **in place**. The array is passed in as `dataframe_transposed.values`. In **pandas >= 3.0** (and with newer numpy), `DataFrame.values` returns a **read-only** array by default (copy-on-write), so the in-place writes fail.

This is why the reporter saw the same data work under an older Python/pandas stack but break on a newer one — it was never the Python version itself, but the pandas/numpy versions that ship with it.

### Fix

Operate on a writable float copy at the top of the function:

```python
data = np.array(data, dtype=float)
```

This resolves the crash and, as a bonus, stops the function from mutating the caller's array (it now returns a fresh array as the name implies).

## Testing

- Reproduced the exact `ValueError` on the default pandas 3.0 path before the change.
- Added regression tests in `biolearn/test/test_dunedin_pace.py` covering: read-only input, no mutation of the caller's array, and correct mapping onto the target distribution.
- Verified end-to-end against `test_model.py::test_dunedin_pace_normalization`: on `master` it fails at the read-only line; with this change it gets past normalization.

## Note

While verifying end-to-end on a pandas 3.0 environment, I noticed a **separate, pre-existing** failure further downstream in the DunedinPACE test path (a `KeyError` from an integer `RangeIndex` where CpG labels are expected). It is unrelated to this read-only fix and is masked on `master` because the read-only error aborts earlier. I've kept it out of this PR and am happy to open a separate issue/PR for it.