### PR TITLE
test: fix test_dunedin_pace_normalization on pandas 3.0 (fixture orientation)

### DIFF
--- a/biolearn/test/test_model.py
+++ b/biolearn/test/test_model.py
@@ -110,20 +110,31 @@ def test_dunedin_pace_normalization():
     with open(data_file_path, "rb") as file:
         expected = pickle.load(file)
 
-    # Finding mismatches based on tolerance
-    mask = np.abs(actual - expected) > 0.000001
-    mismatches = actual[mask].stack()
+    # The reference fixture stores probe IDs in an ``ID_REF`` column with a
+    # default RangeIndex, whereas the loader returns CpG-indexed data. Align the
+    # fixture's orientation to ``actual`` before comparing; otherwise the axes
+    # don't match and the comparison is vacuous. (On older pandas ``stack()``
+    # silently dropped the misaligned NaNs, so this test passed without ever
+    # comparing values; pandas 3.0 keeps them, surfacing a KeyError instead.)
+    if "ID_REF" in expected.columns:
+        expected = expected.set_index("ID_REF")
+        expected.index.name = actual.index.name
+    expected = expected.reindex(index=actual.index, columns=actual.columns)
 
-    total_mismatches = mismatches.size
+    # Count mismatches from the boolean mask directly, independent of how
+    # ``stack()`` treats NaNs across pandas versions.
+    mismatch_mask = np.abs(actual - expected) > 0.000001
+    total_mismatches = int(mismatch_mask.to_numpy().sum())
     percentage_mismatched = (total_mismatches / actual.size) * 100
 
-    # Display the mismatches
-    for idx, value in enumerate(mismatches.items()):
-        if idx == 100:
-            break
-        print(
-            f"Location: {value[0]}, Actual: {actual.at[value[0]]}, Expected: {expected.at[value[0]]}"
-        )
+    # Display up to the first 100 mismatching cells, if any.
+    if total_mismatches:
+        stacked = mismatch_mask.stack()
+        for row, col in stacked[stacked].index[:100]:
+            print(
+                f"Location: ({row}, {col}), "
+                f"Actual: {actual.at[row, col]}, Expected: {expected.at[row, col]}"
+            )
 
     print(
         f"Total mismatches: {total_mismatches} ({percentage_mismatched:.2f}%)"


### PR DESCRIPTION
## Summary

Fixes #209.

`test_dunedin_pace_normalization` fails on **pandas 3.0** with
`KeyError: 'cg00000029'`. The DunedinPACE normalization output is **correct** —
the problem is that the test compares against a reference fixture in a different
axis orientation, and the comparison logic depended on `stack()`'s NaN handling.

### Root cause

- `actual` (live loader output) is **CpG-indexed** (index = `cg00000029`, …;
  columns = sample GSMs).
- `expected` (`testset/pace_normalized.pkl`) stores probe IDs in an **`ID_REF`
  column** with a default integer **`RangeIndex`**.

The axes never aligned. On older pandas, `DataFrame.stack()` silently dropped
the misaligned NaNs, so `actual[mask].stack()` was empty and the test passed
**without ever comparing values**. On pandas 3.0 the NaNs are kept, so the
diagnostic loop runs and does a label-based `.at[('cg00000029', …)]` lookup
against the `RangeIndex`, raising `KeyError`. (This only surfaces once the
read-only-array fix from #206 lets normalization run to completion; before that,
it aborted earlier with a `ValueError`.)

### Fix

- Align the fixture's orientation to `actual` before comparing (promote `ID_REF`
  to the index and reindex to `actual`'s axes).
- Count mismatches from the boolean mask directly, so the result no longer
  depends on version-specific `stack()` NaN handling.

The normalization computation is untouched — after realignment the values match
the fixture to ~5e-16 (0 of 200000 cells exceed the 1e-6 tolerance).

## Testing

- `pytest biolearn/test/test_model.py::test_dunedin_pace_normalization` — now
  **passes** on Python 3.11 / pandas 3.0.3 / numpy 2.4.6 (previously errored).
- Full `test_model.py` + `test_dunedin_pace.py` green on the same stack, apart
  from pre-existing, unrelated `test_models[GPAge*]` failures (missing optional
  `GPy` dependency in my local env).
- `black --check` clean.

## Note

This is the test-side fix I offered in #209, chosen because it's fully reviewable
in plain code and keeps the existing fixture. If you'd rather **regenerate
`pace_normalized.pkl`** in the current CpG-indexed orientation instead, happy to
switch to that — just let me know.
